### PR TITLE
automatically determine 'shuffle' based on context

### DIFF
--- a/man/input_fn.Rd
+++ b/man/input_fn.Rd
@@ -14,11 +14,11 @@
 \method{input_fn}{formula}(object, data, ...)
 
 \method{input_fn}{data.frame}(object, features, response = NULL,
-  batch_size = 128, shuffle = TRUE, num_epochs = 1,
+  batch_size = 128, shuffle = "auto", num_epochs = 1,
   queue_capacity = 1000, num_threads = 1)
 
 \method{input_fn}{list}(object, features, response = NULL, batch_size = 128,
-  shuffle = TRUE, num_epochs = 1, queue_capacity = 1000,
+  shuffle = "auto", num_epochs = 1, queue_capacity = 1000,
   num_threads = 1)
 
 \method{input_fn}{matrix}(object, ...)
@@ -32,8 +32,9 @@
 
 \item{batch_size}{The size of batches}
 
-\item{shuffle}{Whether to shuffles the queue. Avoid shuffle at prediction
-time}
+\item{shuffle}{Whether to shuffle the queue. When \code{"auto"} (the default),
+shuffling will be performed except when this input function is called by
+a \code{predict()} method.}
 
 \item{num_epochs}{The number of epochs to iterate over data. If \code{NULL} will
 run forever.}

--- a/vignettes/examples/mnist.R
+++ b/vignettes/examples/mnist.R
@@ -115,10 +115,7 @@ train(classifier, input_fn = mnist_input_fn(mnist$train), steps = 200)
 evaluate(classifier, input_fn = mnist_input_fn(mnist$test), steps = 200)
 
 # use our classifier to predict labels for a subset of the test dataset
-predictions <- predict(
-  classifier,
-  input_fn = mnist_input_fn(mnist$test, shuffle = FALSE)
-)
+predictions <- predict(classifier, input_fn = mnist_input_fn(mnist$test))
 
 # plot predictions versus actual for small subset
 n <- 20


### PR DESCRIPTION
This PR adds `"auto"` as a possible argument to the `shuffle` argument for `input_fn()`, and uses that to determine (at run time) whether shuffling is appropriate or not. Currently, shuffling is enabled by default, but disabled when called within the context of a `predict()` function.

This might be a little bit too cute but I'd really like to have us do the right thing by default wherever possible.