### PR TITLE
support (condition) ~ (op) for feature columns

### DIFF
--- a/tests/testthat/test-feature-columns.R
+++ b/tests/testthat/test-feature-columns.R
@@ -9,3 +9,36 @@ test_that("feature columns can be constructed correctly", {
   expect_equal(length(fcs), 2)
   expect_true(grepl("NumericColumn", class(fcs[[1]])[1]))
 })
+
+test_that("feature columns can be constructed with (cond) ~ (op) syntax", {
+  
+  names <- do.call(paste0, expand.grid(letters, 0:9))
+  
+  # bare calls (no extra arguments to column function)
+  mild <- feature_columns(
+    column_numeric(starts_with("a")),
+    names = names
+  )
+  
+  spicy <- feature_columns(
+    starts_with("a") ~ column_numeric(),
+    names = names
+  )
+  
+  expect_equal(mild, spicy)
+  
+  # extra arguments to 'column_numeric()'
+  mild <- feature_columns(
+    column_numeric(starts_with("a"), shape = 1L),
+    names = names
+  )
+  
+  spicy <- feature_columns(
+    starts_with("a") ~ column_numeric(shape = 1L),
+    names = names
+  )
+  
+  expect_equal(mild, spicy)
+  
+})
+


### PR DESCRIPTION
This PR adds support for feature column definitions of the form e.g.

    starts_with("a") ~ column_numeric()

Note that the original formulation, e.g.

    column_numeric(starts_with("a"))

continues to work as-is (we actually transform the call in the first case to the form of the second case).
