### PR TITLE
Fix classes coercion in mnist example

### DIFF
--- a/vignettes/examples/mnist.R
+++ b/vignettes/examples/mnist.R
@@ -121,9 +121,9 @@ predictions <- predict(classifier, input_fn = mnist_input_fn(mnist$test))
 # plot predictions versus actual for small subset
 n <- 20
 indices <- sample(nrow(mnist$test$x), n)
-classes <- vapply(indices, function(i) {
-  predictions[[i]]$classes
-}, character(1))
+classes <- lapply(indices, function(i) {
+  predictions[[i]]$class_ids
+})
 
 data <- array(mnist$test$x[indices, ], dim = c(n, 28, 28))
 melted <- melt(data, varnames = c("image", "x", "y"), value.name = "intensity")


### PR DESCRIPTION
Executing `mnist.R` I get the following error:

```
...
> indices <- sample(nrow(mnist$test$x), n)
> classes <- vapply(indices, function(i) {
+   predictions[[i]]$classes
+ }, character(1))
Error in vapply(indices, function(i) { : values must be type 'character',
 but FUN(X[[1]]) result is type 'list'
```