### PR TITLE
Add debug logging to train()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,7 +38,7 @@ Imports:
     purrr,
     tibble
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 6.0.1
+RoxygenNote: 6.0.1.9000
 Suggests:
     modelr (>= 0.1.1),
     testthat,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,7 +38,7 @@ Imports:
     purrr,
     tibble
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 6.0.1.9000
+RoxygenNote: 6.0.1
 Suggests:
     modelr (>= 0.1.1),
     testthat,

--- a/R/tf_estimator.R
+++ b/R/tf_estimator.R
@@ -127,7 +127,7 @@ train.tf_estimator <- function(object,
 
   args$hooks <- resolve_train_hooks(hooks, verbose, steps, view_metrics, object)
   
-  logging_level <- if (debug_level) tf$logging$DEBUG else tf$logging$WARN
+  logging_level <- if (debug_logging) tf$logging$DEBUG else tf$logging$WARN
   with_logging_verbosity(logging_level, {
     do.call(object$estimator$train, args)
   })

--- a/R/tf_estimator.R
+++ b/R/tf_estimator.R
@@ -98,6 +98,7 @@ NULL
 #' used for callbacks that run immediately before or after checkpoint savings.
 #' @param verbose Show progress output as the model is trained?
 #' @param view_metrics View training metrics as the model is trained?
+#' @param debug_logging Enable debug level logging?
 #' @param ... Optional arguments, passed on to the estimator's `train()` method.
 #'
 #' @export
@@ -110,6 +111,7 @@ train.tf_estimator <- function(object,
                                saving_listeners = NULL,
                                verbose = TRUE,
                                view_metrics = "auto",
+                               debug_logging = FALSE,
                                ...)
 {
   args <- list(
@@ -125,7 +127,8 @@ train.tf_estimator <- function(object,
 
   args$hooks <- resolve_train_hooks(hooks, verbose, steps, view_metrics, object)
   
-  with_logging_verbosity(tf$logging$WARN, {
+  logging_level <- if (debug_level) tf$logging$DEBUG else tf$logging$WARN
+  with_logging_verbosity(logging_level, {
     do.call(object$estimator$train, args)
   })
   

--- a/man/train.tf_estimator.Rd
+++ b/man/train.tf_estimator.Rd
@@ -6,7 +6,7 @@
 \usage{
 \method{train}{tf_estimator}(object, input_fn, steps = NULL, hooks = NULL,
   max_steps = NULL, saving_listeners = NULL, verbose = TRUE,
-  view_metrics = "auto", ...)
+  view_metrics = "auto", debug_logging = FALSE, ...)
 }
 \arguments{
 \item{object}{A TensorFlow estimator.}
@@ -32,6 +32,8 @@ used for callbacks that run immediately before or after checkpoint savings.}
 \item{verbose}{Show progress output as the model is trained?}
 
 \item{view_metrics}{View training metrics as the model is trained?}
+
+\item{debug_logging}{Enable debug level logging?}
 
 \item{...}{Optional arguments, passed on to the estimator's \code{train()} method.}
 }


### PR DESCRIPTION
Small PR found while troubleshooting cloudml issue, I found this setting a bit helpful but not super helpful. Passing PR in case the change looks interesting.

When `debug_logging`, one can get additional logging, as in:

<img width="1100" alt="screen shot 2017-11-08 at 4 56 10 pm" src="https://user-images.githubusercontent.com/3478847/32582871-c9af7054-c4a5-11e7-9747-85b6ef8739c5.png">
