### PR TITLE
Refactor internal constructors

### DIFF
--- a/R/dnn_estimators.R
+++ b/R/dnn_estimators.R
@@ -51,7 +51,7 @@ dnn_regressor <- function(hidden_units,
     )
   )
 
-  tf_regressor(estimator, "dnn_regressor")
+  new_tf_regressor(estimator, subclass = "tf_estimator_regressor_dnn_regressor")
 }
 
 #' @inheritParams dnn_estimators
@@ -87,6 +87,7 @@ dnn_classifier <- function(hidden_units,
     )
   )
 
-  tf_classifier(estimator, "dnn_classifier", args)
+  new_tf_classifier(estimator, args = args, 
+                    subclass = "tf_estimator_classifier_dnn_classifier")
 }
 

--- a/R/dnn_estimators.R
+++ b/R/dnn_estimators.R
@@ -36,6 +36,8 @@ dnn_regressor <- function(hidden_units,
                           input_layer_partitioner = NULL,
                           config = NULL)
 {
+  args <- as.list(environment(), all = TRUE)
+  
   estimator <- py_suppress_warnings(
     tf$estimator$DNNRegressor(
       hidden_units = as.integer(hidden_units),
@@ -51,7 +53,8 @@ dnn_regressor <- function(hidden_units,
     )
   )
 
-  new_tf_regressor(estimator, subclass = "tf_estimator_regressor_dnn_regressor")
+  new_tf_regressor(estimator, args = args,
+                   subclass = "tf_estimator_regressor_dnn_regressor")
 }
 
 #' @inheritParams dnn_estimators

--- a/R/dnn_linear_combined_estimators.R
+++ b/R/dnn_linear_combined_estimators.R
@@ -65,7 +65,8 @@ dnn_linear_combined_regressor <- function(model_dir = NULL,
     )
   )
 
-  new_tf_regressor(estimator, subclass = "tf_estimator_dnn_linear_combined_regressor")
+  new_tf_regressor(estimator, args = args,
+                   subclass = "tf_estimator_dnn_linear_combined_regressor")
 }
 
 #' @inheritParams dnn_linear_combined_estimators

--- a/R/dnn_linear_combined_estimators.R
+++ b/R/dnn_linear_combined_estimators.R
@@ -65,7 +65,7 @@ dnn_linear_combined_regressor <- function(model_dir = NULL,
     )
   )
 
-  tf_regressor(estimator, "dnn_linear_combined_regressor", args)
+  new_tf_regressor(estimator, subclass = "tf_estimator_dnn_linear_combined_regressor")
 }
 
 #' @inheritParams dnn_linear_combined_estimators
@@ -105,5 +105,6 @@ dnn_linear_combined_classifier <- function(model_dir = NULL,
     )
   )
 
-  tf_classifier(estimator, "dnn_linear_combined_classifier", args)
+  new_tf_classifier(estimator, args = args,
+                    subclass = "tf_estimator_classifier_dnn_linear_combined_classifier")
 }

--- a/R/linear_estimators.R
+++ b/R/linear_estimators.R
@@ -39,7 +39,8 @@ linear_regressor <- function(feature_columns,
     )
   )
 
-  tf_regressor(estimator, "linear_regressor", args)
+  new_tf_regressor(estimator, args = args, 
+                   subclass = "tf_estimator_regressor_linear_regressor")
 }
 
 #' @inheritParams linear_estimators
@@ -69,5 +70,6 @@ linear_classifier <- function(feature_columns,
     )
   )
 
-  tf_classifier(estimator, "linear_classifier", args)
+  new_tf_classifier(estimator, args = args,
+                    subclass = "tf_estimator_classifier_linear_classifier")
 }

--- a/R/tf_custom_estimator.R
+++ b/R/tf_custom_estimator.R
@@ -1,11 +1,7 @@
-tf_custom_estimator <- function(estimator, model_fn, classes) {
-  structure(
-    list(
-      estimator = estimator,
-      model_fn  = model_fn
-    ),
-    class = c("tf_estimator", "tf_custom_estimator", classes)
-  )
+new_tf_custom_estimator <- function(
+  estimator, args = NULL, model_fn, ..., subclass = NULL) {
+  new_tf_estimator(estimator, args = args, model_fn = model_fn, ...,
+                   subclass = c(subclass, "tf_custom_estimator"))
 }
 
 #' Define an Estimator Specification
@@ -161,7 +157,8 @@ estimator <- function(model_fn,
     config = config,
     params = params
   ))
-  tf_custom_estimator(estimator, model_fn, class)
+
+  new_tf_custom_estimator(estimator, model_fn = model_fn, subclass = class)
 }
 
 as_model_fn <- function(f) {

--- a/R/tf_estimator.R
+++ b/R/tf_estimator.R
@@ -1,19 +1,22 @@
-tf_estimator <- function(estimator, classes, history = NULL, args = NULL) {
+new_tf_estimator <- function(estimator, args = NULL, ..., 
+                             subclass = NULL) {
   structure(
     list(
       estimator = estimator,
       history = history,
       args = args),
-    class = c("tf_estimator", paste("tf_estimator", classes, sep = "_"))
+    class = c(subclass, "tf_estimator")
   )
 }
 
-tf_regressor <- function(estimator, class, args = NULL) {
-  tf_estimator(estimator, c("regressor", class), args = args)
+new_tf_regressor <- function(estimator, args = NULL, ..., subclass = NULL) {
+  new_tf_estimator(estimator, args = args, ..., 
+                   subclass = c(subclass, "tf_estimator_regressor"))
 }
 
-tf_classifier <- function(estimator, class, args = NULL) {
-  tf_estimator(estimator, c("classifier", class), args = args)
+new_tf_classifier <- function(estimator, args = NULL, ..., subclass = NULL) {
+  new_tf_estimator(estimator, args = args, ..., 
+                   subclass = c(subclass, "tf_estimator_classifier"))
 }
 
 is.tf_custom_estimator <- function(object) {

--- a/R/tf_estimator.R
+++ b/R/tf_estimator.R
@@ -3,8 +3,8 @@ new_tf_estimator <- function(estimator, args = NULL, ...,
   structure(
     list(
       estimator = estimator,
-      history = history,
-      args = args),
+      args = args,
+      ...),
     class = c(subclass, "tf_estimator")
   )
 }


### PR DESCRIPTION
- Clean up internal constructors a bit to ensure proper inheritance
- Remove unused `history` argument of `tf_estimator` constructor
- Add `args` to canned estimator constructors that were missing it (this is necessary for model exporting)