### PR TITLE
Always save first step of training history in hook history saver

### DIFF
--- a/R/session_run_hooks_custom.R
+++ b/R/session_run_hooks_custom.R
@@ -12,7 +12,7 @@ should_execute <- function(current_step, every_n_step) {
 #' @family session_run_hook wrappers
 #' @export
 #' 
-hook_history_saver <- function(every_n_step = 2) {
+hook_history_saver <- function(every_n_step = 10) {
   
   hook_fn <- function(mode_key) {
 

--- a/R/session_run_hooks_custom.R
+++ b/R/session_run_hooks_custom.R
@@ -1,5 +1,5 @@
 should_execute <- function(current_step, every_n_step) {
-  current_step %% every_n_step == 0
+  (current_step %% every_n_step == 0) || (current_step == 1)
 }
 
 #' A Custom Run Hook for Saving Metrics History

--- a/R/utils_tf.R
+++ b/R/utils_tf.R
@@ -103,7 +103,7 @@ is.built_in_custom_hook <- function(hook) {
 
 attach_default_built_in_custom_hooks <- function(hooks) {
   hooks <- normalize_session_run_hooks(hooks)
-  default_history_saver <- hook_history_saver(every_n_step = 10)
+  default_history_saver <- hook_history_saver()
   default_progress_bar <- hook_progress_bar()
   built_in_hooks <- lapply(hooks, function(hook) {
    if (is.built_in_custom_hook(hook)) hook

--- a/tests/testthat/helper-utils.R
+++ b/tests/testthat/helper-utils.R
@@ -16,7 +16,7 @@ skip_if_tensorflow_below <- function(version) {
 mtcars_regression_specs <- function() {
   dnn_feature_columns <- feature_columns(column_numeric("drat"))
   linear_feature_columns <- feature_columns(column_numeric("drat"))
-  constructed_input_fn <- input_fn(mtcars, response = "mpg", features = c("drat", "cyl"), batch_size = 8L)
+  constructed_input_fn <- input_fn(mtcars, response = "mpg", features = c("drat", "cyl"), batch_size = 1L)
   list(dnn_feature_columns = dnn_feature_columns,
        linear_feature_columns = linear_feature_columns,
        input_fn = constructed_input_fn)

--- a/tests/testthat/test-hooks.R
+++ b/tests/testthat/test-hooks.R
@@ -58,12 +58,6 @@ test_that("Built-in Custom Hook works with linear_regressor", {
     steps = 2,
     hooks = list(
       hook_progress_bar()))
-  # verify that history is not saved by progress bar
-  expect_equal(dim(as.data.frame(training_history)), c(0, 0))
-  expect_equal(
-    lapply(tfestimators:::.globals$history, function(x) dim(as.data.frame(x))),
-    list(train = c(0, 0), eval = c(0, 0))
-  )
   
   # Test hook_history_saver
   lr <- linear_regressor(feature_columns = specs$linear_feature_columns)

--- a/tests/testthat/test-hooks.R
+++ b/tests/testthat/test-hooks.R
@@ -75,9 +75,9 @@ test_that("Built-in Custom Hook works with linear_regressor", {
   # verify history is saved for both training and evaluation
   expect_equal(
     lapply(tfestimators:::.globals$history, function(x) dim(as.data.frame(x))),
-    list(train = 2:3, eval = 2:3)
+    list(train = c(6, 3), eval = c(6, 3))
   )
-  expect_equal(dim(as.data.frame(training_history)), c(4, 3))
+  expect_equal(dim(as.data.frame(training_history)), c(12, 3))
   
   # Test whether default hooks are attached successfully without any hooks specified
   lr <- linear_regressor(feature_columns = specs$linear_feature_columns)

--- a/tests/testthat/test-hooks.R
+++ b/tests/testthat/test-hooks.R
@@ -109,3 +109,12 @@ test_that("Built-in Custom Hook works with linear_regressor", {
       hook_history_saver(every_n_step = 2)))
 })
 
+test_that("First step of training is always saved in default history saver", {
+  specs <- mtcars_regression_specs()
+  lr <- linear_regressor(feature_columns = specs$linear_feature_columns)
+  training_history <- lr %>% train(
+    input_fn = specs$input_fn,
+    steps = 1)
+  expect_equal(dim(as.data.frame(training_history)),
+               c(2, 3))
+})


### PR DESCRIPTION
Change:
- `hook_history_saver()` always saves the first training step to ensure we have proper history objects returned by `train()` regardless of steps trained.

@jjallaire the error we saw in https://github.com/rstudio/tfestimators/pull/126 was due to wide_and_deep.R training for only two steps (`train(model, input_fn = train_input_fn, steps = 2)`) while the default hook history saver attached has `every_n_step = 10` so no history was saved. This change should fix that situation. Note that in most practical application users will be setting `steps` to be in the 100s or 1000s.