### PR TITLE
Don't complete progress bar upon training completion

### DIFF
--- a/R/session_run_hooks_custom.R
+++ b/R/session_run_hooks_custom.R
@@ -101,12 +101,12 @@ hook_progress_bar <- function() {
       },
       
       end = function(session) {
-        
-        # if we ran as many steps as expected, bail
-        if (is.null(steps) || identical(.n, steps))
-          return()
-        
-        update_progress(.values, steps - .n)
+        # notify user if didn't train for steps specified
+        if (!is.null(steps) && !identical(.n, steps)) {
+          msg <- paste0("\nTraining completed after ", .n, " steps ",
+                        "but ", steps, " steps was specified")
+          message(msg)
+        }
       }
       
     )


### PR DESCRIPTION
- Don't complete progress bar upon training completion and outputs message if didn't train for `steps` steps.

Behavior with this change:
```
model <- linear_regressor(feature_columns(column_numeric("drat", "cyl")))
model %>% train(
  input_fn(mtcars, features = c("drat", "cyl"), response = "mpg",
           batch_size = 1
  ),
  steps = 100
)
# Training 32/100 [=========....................] - ETA:  1s - loss: 36.73
# Training completed after 32 steps but 100 steps was specified
```
Closes https://github.com/rstudio/tfestimators/issues/125