### PR TITLE
Increase `export_savedmodel` tests

### DIFF
--- a/tests/testthat/test-save.R
+++ b/tests/testthat/test-save.R
@@ -12,26 +12,44 @@ check_contents <- function(path) {
   unlink(path, recursive = TRUE)
 }
 
-test_succeeds("export_savedmodel() runs successfully", {
-  specs <- mtcars_regression_specs()
-  
-  model <- linear_regressor(feature_columns = specs$linear_feature_columns)
-  model %>% train(input_fn = specs$input_fn, steps = 2)
-  
-  temp_path <- file.path(tempdir(), "testthat-save")
+export_test_savedmodel <- function(model) {
+  temp_path <- file.path(tempfile(), "testthat-save")
   if (dir.exists(temp_path)) unlink(temp_path, recursive = TRUE)
   
   export_savedmodel(model, temp_path)
   
   check_contents(temp_path)
-  
-  # Test canned estimators with multiple feature columns in args
+}
+
+test_succeeds("export_savedmodel() runs successfully for linear_regressor", {
   specs <- mtcars_regression_specs()
+  
+  model <- linear_regressor(feature_columns = specs$linear_feature_columns)
+  model %>% train(input_fn = specs$input_fn, steps = 2)
+
+  export_test_savedmodel(model)
+})
+
+test_succeeds("export_savedmodel() runs successfully for dnn_linear_combined_regressor", {
+  specs <- mtcars_regression_specs()
+  
   model <- dnn_linear_combined_regressor(
     linear_feature_columns = specs$linear_feature_columns,
     dnn_feature_columns = specs$dnn_feature_columns,
     dnn_hidden_units = c(3, 3))
   model %>% train(input_fn = specs$input_fn, steps = 2)
-  export_savedmodel(model, temp_path)
-  check_contents(temp_path)
+  
+  export_test_savedmodel(model)
+})
+
+test_succeeds("export_savedmodel() runs successfully for dnn_regressor", {
+  specs <- mtcars_regression_specs()
+
+  model <- dnn_regressor(
+    hidden_units = c(3,3),
+    feature_columns = specs$linear_feature_columns
+  )
+  model %>% train(input_fn = specs$input_fn, steps = 2)
+
+  export_test_savedmodel(model)
 })

--- a/tests/testthat/test-save.R
+++ b/tests/testthat/test-save.R
@@ -53,3 +53,36 @@ test_succeeds("export_savedmodel() runs successfully for dnn_regressor", {
 
   export_test_savedmodel(model)
 })
+
+test_succeeds("export_savedmodel() runs successfully for linear_classifier", {
+  specs <- mtcars_classification_specs()
+  
+  model <- linear_classifier(feature_columns = specs$linear_feature_columns)
+  model %>% train(input_fn = specs$input_fn, steps = 2)
+  
+  export_test_savedmodel(model)
+})
+
+test_succeeds("export_savedmodel() runs successfully for dnn_linear_combined_classifier", {
+  specs <- mtcars_classification_specs()
+  
+  model <- dnn_linear_combined_classifier(
+    linear_feature_columns = specs$linear_feature_columns,
+    dnn_feature_columns = specs$dnn_feature_columns,
+    dnn_hidden_units = c(3, 3))
+  model %>% train(input_fn = specs$input_fn, steps = 2)
+  
+  export_test_savedmodel(model)
+})
+
+test_succeeds("export_savedmodel() runs successfully for dnn_classifier", {
+  specs <- mtcars_classification_specs()
+  
+  model <- dnn_classifier(
+    hidden_units = c(3,3),
+    feature_columns = specs$linear_feature_columns
+  )
+  model %>% train(input_fn = specs$input_fn, steps = 2)
+  
+  export_test_savedmodel(model)
+})


### PR DESCRIPTION
Increase `export_savedmodel` tests to cover all regressors and classifiers.