### PR TITLE
Make export_savedmodel() use raw tensors

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: tfestimators
 Type: Package
 Title: Interface to 'TensorFlow' Estimators
-Version: 1.4.3.9000
+Version: 1.4.2.9000
 Authors@R: c(
   person("JJ", "Allaire", role = c("aut", "cre"),
          email = "jj@rstudio.com"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: tfestimators
 Type: Package
 Title: Interface to 'TensorFlow' Estimators
-Version: 1.4.2
+Version: 1.4.3.9000
 Authors@R: c(
   person("JJ", "Allaire", role = c("aut", "cre"),
          email = "jj@rstudio.com"),


### PR DESCRIPTION
Back when `export_savedmodel()` was implemented in `tfestimators`, the [build_parsing_serving_input_receiver_fn](https://www.tensorflow.org/api_docs/python/tf/estimator/export/build_parsing_serving_input_receiver_fn) was used, while not incorrect, this input function expects a [tf.Example](https://github.com/tensorflow/tensorflow/blob/r1.4/tensorflow/core/example/example.proto) which happens to be a protobuf structure that can be constructed using a few helpers like `tf.parse_example()`; however, passing protobuf structures is not straightforward to use nor compatible with other `export_savedmodel()` implementations.

Instead, this PR switches the implementation to use [build_raw_serving_input_receiver_fn](https://www.tensorflow.org/api_docs/python/tf/estimator/export/build_raw_serving_input_receiver_fn) which requires raw tensors that are compatible with other package implementations. A good example that informs this implementaiton was found under [/tensorflow/models/official/mnist/](https://github.com/tensorflow/models/blob/72f5834cc19bcfd3aef795dd926575fd9e0db802/official/mnist/mnist.py).
  
However, since multiple input/output tensors support was added until TF 1.4 (see [/tensorflow/issues/12367](https://github.com/tensorflow/tensorflow/issues/12367#issuecomment-335320352)), this change fallbacks to parsing serving input as protobuf inputs for earlier versions.