### PR TITLE
Avoid false positives for export test if test environment is not clean

### DIFF
--- a/tests/testthat/test-save.R
+++ b/tests/testthat/test-save.R
@@ -16,7 +16,7 @@ export_test_savedmodel <- function(model) {
   temp_path <- file.path(tempfile(), "testthat-save")
   if (dir.exists(temp_path)) unlink(temp_path, recursive = TRUE)
   
-  export_savedmodel(model, temp_path)
+  export_savedmodel(model, temp_path, overwrite = FALSE)
   
   check_contents(temp_path)
 }


### PR DESCRIPTION
This fixed the warnings and failures that I mentioned in the email:

```
Warnings -------------------------------------------------------------------------------
1. export_savedmodel() runs successfully for linear_regressor (@helper-utils.R#21) - problem copying b'/var/folders/v1/wn5zfxx114z390lk9s444f6w0000gn/T//Rtmpbr71RO/1516294277'/. to /var/folders/v1/wn5zfxx114z390lk9s444f6w0000gn/T//Rtmpbr71RO/file45e47d0551e7/testthat-save/.: No such file or directory

Failed ---------------------------------------------------------------------------------
1. Failure: export_savedmodel() runs successfully for linear_regressor (@helper-utils.R#21) 
any(grepl("saved_model\\.pb", dir_contents)) isn't true.
```
@jjallaire @kevinykuo 