### PR TITLE
Use placeholder with default to prevent missing values error in graph

### DIFF
--- a/R/tf_estimator.R
+++ b/R/tf_estimator.R
@@ -371,7 +371,10 @@ export_savedmodel.tf_estimator <- function(object,
       features <- list()
       for (feature in feature_columns_spec) {
         # first dimension is variable since it's required by cloudml-like interfaces to push multiple instances
-        features[[feature$name]] <- tf$placeholder_with_default(shape = shape(NULL, feature$shape), dtype = feature$dtype)
+        features[[feature$name]] <- tf$placeholder_with_default(
+          input = feature$dtype$min,
+          shape = shape(NULL, feature$shape)
+        )
       }
       
       serving_input_receiver_fn <- tf$estimator$export$build_raw_serving_input_receiver_fn(features)

--- a/R/tf_estimator.R
+++ b/R/tf_estimator.R
@@ -370,9 +370,11 @@ export_savedmodel.tf_estimator <- function(object,
     } else {
       features <- list()
       for (feature in feature_columns_spec) {
+        default_tensor <- tf$constant(value = feature$dtype$min, shape = shape(1, feature$shape))
+        
         # first dimension is variable since it's required by cloudml-like interfaces to push multiple instances
         features[[feature$name]] <- tf$placeholder_with_default(
-          input = feature$dtype$min,
+          input = default_tensor,
           shape = shape(NULL, feature$shape)
         )
       }

--- a/R/tf_estimator.R
+++ b/R/tf_estimator.R
@@ -371,7 +371,7 @@ export_savedmodel.tf_estimator <- function(object,
       features <- list()
       for (feature in feature_columns_spec) {
         # first dimension is variable since it's required by cloudml-like interfaces to push multiple instances
-        features[[feature$name]] <- tf$placeholder(shape = shape(NULL, feature$shape), dtype = feature$dtype)
+        features[[feature$name]] <- tf$placeholder_with_default(shape = shape(NULL, feature$shape), dtype = feature$dtype)
       }
       
       serving_input_receiver_fn <- tf$estimator$export$build_raw_serving_input_receiver_fn(features)


### PR DESCRIPTION
See https://github.com/rstudio/tfdeploy/issues/15

The graph appears to clear, but the state requiring this placeholder remains. It is still unclear to me why even after creating a new session in `tfdeploy` and triggering `tf$reset_default_graph()` the placeholder is still around. But I see no tradeoff in using placeholder with defaults instead of placeholder that might require a value if session is not fully cleared. 