### PR TITLE
Fixes #153: Added boosted trees estimators to docs

### DIFF
--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -51,6 +51,8 @@ reference:
       - dnn_classifier
       - dnn_linear_combined_regressor
       - dnn_linear_combined_classifier
+      - boosted_trees_regressor
+      - boosted_trees_classifier
       
   - title: "Estimator Methods"
     contents:


### PR DESCRIPTION
I only edited `pkgdown.yml` and then did a `pkgdown::build_reference()`. I tried both CRAN and Github version of `pkgdown` but still got a huge diff so I figured I'll just update them at once here. BTW @jjallaire where is the tensorflow docs repo now? I couldn't find it anymore. Is `/docs` folder still needed?