### PR TITLE
Prepare 1.9.1 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 
 language: r
 
-warnings_are_errors: false
+warnings_are_errors: true
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ env:
     - TF_VERSION="1.8"
     - TF_VERSION="1.9"
     - TF_VERSION="1.10"
+    - TF_VERSION="1.11"
     - TF_VERSION="nightly"
 
 os:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: tfestimators
 Type: Package
 Title: Interface to 'TensorFlow' Estimators
-Version: 1.9.0.9001
+Version: 1.9.1
 Authors@R: c(
   person("JJ", "Allaire", role = c("aut"),
          email = "jj@rstudio.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# tfestimators 1.9.0.9000 (unreleased)
+# tfestimators 1.9.1
 
 * Fixes for rlang 0.3 compatibility (#156, #159).
 

--- a/R/feature_columns.R
+++ b/R/feature_columns.R
@@ -169,7 +169,7 @@ column_categorical_with_vocabulary_file <- function(...,
       vocabulary_file = vocabulary_file,
       vocabulary_size = vocabulary_size,
       num_oov_buckets = cast_scalar_integer(num_oov_buckets),
-      default_value = cast_nullable_scalar_integer(default_value, allow.null = TRUE),
+      default_value = cast_nullable_scalar_integer(default_value),
       dtype = dtype
     )
   })

--- a/R/session_run_hooks_builtin_wrappers.R
+++ b/R/session_run_hooks_builtin_wrappers.R
@@ -190,7 +190,7 @@ hook_summary_saver <- function(save_steps = NULL,
 #' @export
 hook_global_step_waiter <- function(wait_until_step) {
   tf$python$training$basic_session_run_hooks$GlobalStepWaiterHook(
-    wait_until_step = cast_calar_integer(wait_until_step)
+    wait_until_step = cast_scalar_integer(wait_until_step)
   )
 }
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -5,6 +5,4 @@
 
 ## R CMD check results
 
-0 errors | 0 warnings | 1 note
-
-* Change of maintainer from JJ Allaire to Kevin Kuo.
+0 errors | 0 warnings | 0 notes

--- a/vignettes/creating_estimators.Rmd
+++ b/vignettes/creating_estimators.Rmd
@@ -83,7 +83,7 @@ contains 7 examples on which to make predictions.
 
 The following sections walk through writing the `Estimator` code step by step;
 the [full, final code is available
-here](https://www.tensorflow.org/code/tensorflow/examples/tutorials/estimators/abalone.py).
+here](https://github.com/tensorflow/tensorflow/blob/r1.3/tensorflow/examples/tutorials/estimators/abalone.py).
 
 # Downloading and Loading Abalone CSV Data
 


### PR DESCRIPTION
- The abalone custom estimator example has been removed from the tensorflow repo so I change the link to point to the file from a previous release. We should consider rewriting the tutorial to reflect https://www.tensorflow.org/guide/custom_estimators and https://github.com/tensorflow/models/blob/master/samples/core/get_started/custom_estimator.py.
- Added TF 1.11 to test matrix.
- Enable `warnings_are_errors` in travis.