### PR TITLE
Fix argument injection in `feature_columns()`

### DIFF
--- a/R/feature_columns.R
+++ b/R/feature_columns.R
@@ -25,17 +25,17 @@ feature_columns <- function(..., names = NULL) {
     #
     #     column_numeric(starts_with("a"))
     #
-    expr <- quo_expr(quo)
+    expr <- quo_get_expr(quo)
     if (is_formula(expr, lhs = TRUE)) {
-      
+
       # extract formula expressions
       lhs <- expr[[2]]; rhs <- expr[[3]]
-      
+
       # inject lhs as first argument to rhs
-      injected <- as.call(c(node_car(get_expr(rhs)), lhs, node_cdr(get_expr(rhs))))
-      
+      injected <- call_inject_args(rhs, lhs)
+
       # update expression
-      quo <- set_expr(quo, injected)
+      quo <- quo_set_expr(quo, injected)
     }
     
     rlang::eval_tidy(quo)

--- a/R/utils_miscs.R
+++ b/R/utils_miscs.R
@@ -56,3 +56,15 @@ resolve_mode <- function() {
   
   mode
 }
+
+# Inserts `...` at the front of the argument list of `call`.
+# `call` must be a call, possibly wrapped in a formula or quosure.
+call_inject_args <- function(call, ...) {
+  expr <- get_expr(call)
+
+  stopifnot(is.call(expr))
+  args <- call_args(expr)
+  new <- call_modify(expr[1], ..., !!!args)
+
+  set_expr(call, new)
+}


### PR DESCRIPTION
- Remove use of deprecated `quo_expr()`. It was renamed in rlang 0.2.0 to `quo_squash()` to make it clear that it's not a quosure accessor. Instead, it recursively unwraps all quosures in the expression tree. It seems the quosure accessor `quo_get_expr()` is the intended function here.

- Replace unsafe use of `node_car()` and `node_cdr()` with a small util `call_inject_args()`. Taking the CAR or CDR on something else than calls will crash R, and the arguments were not type checked.